### PR TITLE
instead of latest use 1.19 to ensure version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG REACT_APP_ENGINE_URL=AAAABBBBCCCC
 ARG REACT_APP_BASE_NAME=DDDDEEEEFFFF
 RUN npm run build
 
-FROM nginx:latest
+FROM nginx:1.19
 COPY --from=builder /app/build /usr/share/nginx/engine
 COPY boot.sh /docker-entrypoint.d/30-fix-ui-vars.sh
 RUN chmod +x /docker-entrypoint.d/30-fix-ui-vars.sh


### PR DESCRIPTION
Using environment variables in Nginx configuration is new in version 1.19 and I realized that using latest somehow did not get the latest so instead maybe we can use this specific version(it is the latest now).