### PR TITLE
use $index_html_url for correct path while mounting on /engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,3 @@ COPY boot.sh /docker-entrypoint.d/30-fix-ui-vars.sh
 RUN chmod +x /docker-entrypoint.d/30-fix-ui-vars.sh
 COPY engine.conf /etc/nginx/templates/default.conf.template
 COPY engine-ssl.conf /etc/nginx/templates/default.conf.template-secure
-ENV index_html_url="/index.html"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ COPY boot.sh /docker-entrypoint.d/30-fix-ui-vars.sh
 RUN chmod +x /docker-entrypoint.d/30-fix-ui-vars.sh
 COPY engine.conf /etc/nginx/templates/default.conf.template
 COPY engine-ssl.conf /etc/nginx/templates/default.conf.template-secure
+ENV index_html_url="/index.html"

--- a/engine-ssl.conf
+++ b/engine-ssl.conf
@@ -15,7 +15,7 @@ server {
     }
     location $mount_url {
         root $root_url;
-        try_files $uri $uri/ $index_html_url =404;
+        try_files $uri $uri/ $mount_url/index.html =404;
     }
     client_max_body_size 0;
 }

--- a/engine-ssl.conf
+++ b/engine-ssl.conf
@@ -15,6 +15,7 @@ server {
     }
     location $mount_url {
         root $root_url;
+        try_files $uri $uri/ $index_html_url =404;
     }
     client_max_body_size 0;
 }

--- a/engine.conf
+++ b/engine.conf
@@ -8,7 +8,7 @@ server {
     }
     location $mount_url {
         root $root_url;
-        try_files $uri $uri/ /index.html =404;
+        try_files $uri $uri/ $index_html_url =404;
     }
     client_max_body_size 0;
 }

--- a/engine.conf
+++ b/engine.conf
@@ -8,7 +8,7 @@ server {
     }
     location $mount_url {
         root $root_url;
-        try_files $uri $uri/ $index_html_url =404;
+        try_files $uri $uri/ $mount_url/index.html =404;
     }
     client_max_body_size 0;
 }


### PR DESCRIPTION
While `engine` is mounted on `/` using URLs and refreshing page via `F5` works but when it is mounted on `/engine` we need to update the location for the index HTML so that refreshing the page also works. 

I declared the env variable in `Dockerfile` because if the environment variable is not provided it is mostly safe to assume it is `/index.html`. Updating the environment variable in docker-compose will override this.

Edit -- I changed the code to not introduce a new env variable because apparently //index.html also works

