### PR TITLE
141 support external authproviders

### DIFF
--- a/10-listen-on-ipv6-by-default.sh
+++ b/10-listen-on-ipv6-by-default.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+
+set -e
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+ME=$(basename $0)
+DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
+
+# check if we have ipv6 available
+if [ ! -f "/proc/net/if_inet6" ]; then
+    entrypoint_log "$ME: info: ipv6 not available"
+    exit 0
+fi
+
+if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
+    entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE is not a file or does not exist"
+    exit 0
+fi
+
+# check if the file can be modified, e.g. not on a r/o filesystem
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { entrypoint_log "$ME: info: can not modify /$DEFAULT_CONF_FILE (read-only file system?)"; exit 0; }
+
+# check if the file is already modified, e.g. on a container restart
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { entrypoint_log "$ME: info: IPv6 listen already enabled"; exit 0; }
+
+if [ -f "/etc/os-release" ]; then
+    . /etc/os-release
+else
+    entrypoint_log "$ME: info: can not guess the operating system"
+    exit 0
+fi
+
+entrypoint_log "$ME: info: Getting the checksum of /$DEFAULT_CONF_FILE"
+
+case "$ID" in
+    "debian")
+        CHECKSUM=$(dpkg-query --show --showformat='${Conffiles}\n' nginx | grep $DEFAULT_CONF_FILE | cut -d' ' -f 3)
+        echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | md5sum -c - >/dev/null 2>&1 || {
+            entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
+            exit 0
+        }
+        ;;
+    "alpine")
+        CHECKSUM=$(apk manifest nginx 2>/dev/null| grep $DEFAULT_CONF_FILE | cut -d' ' -f 1 | cut -d ':' -f 2)
+        echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | sha1sum -c - >/dev/null 2>&1 || {
+            entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
+            exit 0
+        }
+        ;;
+    *)
+        entrypoint_log "$ME: info: Unsupported distribution"
+        exit 0
+        ;;
+esac
+
+# enable ipv6 on default.conf listen sockets
+sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
+
+entrypoint_log "$ME: info: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+
+exit 0

--- a/20-envsubst-on-templates.sh
+++ b/20-envsubst-on-templates.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+ME=$(basename $0)
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+auto_envsubst() {
+  local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
+  local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
+  local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
+  local filter="${NGINX_ENVSUBST_FILTER:-}"
+
+  local template defined_envs relative_path output_path subdir
+  defined_envs=$(printf '${%s} ' $(awk "END { for (name in ENVIRON) { print ( name ~ /${filter}/ ) ? name : \"\" } }" < /dev/null ))
+  [ -d "$template_dir" ] || return 0
+  if [ ! -w "$output_dir" ]; then
+    entrypoint_log "$ME: ERROR: $template_dir exists, but $output_dir is not writable"
+    return 0
+  fi
+  find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
+    relative_path="${template#$template_dir/}"
+    output_path="$output_dir/${relative_path%$suffix}"
+    subdir=$(dirname "$relative_path")
+    # create a subdirectory where the template file exists
+    mkdir -p "$output_dir/$subdir"
+    entrypoint_log "$ME: Running envsubst on $template to $output_path"
+    envsubst "$defined_envs" < "$template" > "$output_path"
+  done
+}
+
+auto_envsubst
+
+exit 0

--- a/30-tune-worker-processes.sh
+++ b/30-tune-worker-processes.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+  num=$1
+  div=$2
+  echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  cpusetfile=$2
+  ncpu=0
+  [ -f "$cpusetroot/$cpusetfile" ] || return 1
+  for token in $( tr ',' ' ' < "$cpusetroot/$cpusetfile" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return 1
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return 1
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return 1
+  [ "$cfs_period" = "0" ] && return 1
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return 1
+  echo "$ncpu"
+}
+
+get_quota_v2() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.max" ] || return 1
+  cfs_quota=$( cut -d' ' -f 1 < "$cpuroot/cpu.max" )
+  cfs_period=$( cut -d' ' -f 2 < "$cpuroot/cpu.max" )
+  [ "$cfs_quota" = "max" ] && return 1
+  [ "$cfs_period" = "0" ] && return 1
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return 1
+  echo "$ncpu"
+}
+
+get_cgroup_v1_path() {
+  needle=$1
+  found=
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return 1
+  [ -r "/proc/self/cgroup" ] || return 1
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            break
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            break
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            break
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            break
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+get_cgroup_v2_path() {
+  found=
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return 1
+  [ -r "/proc/self/cgroup" ] || return 1
+
+  while IFS= read -r line; do
+    found=$( echo "$line" | cut -d ' ' -f 4,5 )
+  done << __EOF__
+$( grep -F -- '- cgroup2 ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    mountpoint=$( echo "$line" | cut -d: -f 3 )
+done << __EOF__
+$( grep -F -- '0::' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "")
+      return 1
+      ;;
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint" | /../*)
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+ncpu_cpuset=
+ncpu_quota=
+ncpu_cpuset_v2=
+ncpu_quota_v2=
+
+cpuset=$( get_cgroup_v1_path "cpuset" ) && ncpu_cpuset=$( get_cpuset "$cpuset" "cpuset.effective_cpus" ) || ncpu_cpuset=$ncpu_online
+cpu=$( get_cgroup_v1_path "cpu" ) && ncpu_quota=$( get_quota "$cpu" ) || ncpu_quota=$ncpu_online
+cgroup_v2=$( get_cgroup_v2_path ) && ncpu_cpuset_v2=$( get_cpuset "$cgroup_v2" "cpuset.cpus.effective" ) || ncpu_cpuset_v2=$ncpu_online
+cgroup_v2=$( get_cgroup_v2_path ) && ncpu_quota_v2=$( get_quota_v2 "$cgroup_v2" ) || ncpu_quota_v2=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
+               "$ncpu_online" \
+               "$ncpu_cpuset" \
+               "$ncpu_quota" \
+               "$ncpu_cpuset_v2" \
+               "$ncpu_quota_v2" \
+               | sort -n \
+               | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,17 +72,17 @@ RUN set -x \
             && su nobody -s /bin/sh -c " \
                 export HOME=${tempDir} \
                 && cd ${tempDir} \
-                && wget https://nginx.org/download/nginx-1.22.0.tar.gz \
-                && PKGOSSCHECKSUM=\"074782dba9cd5f8f493fbb57e20bda6dc9171814d919a47ee9f825d93f12c9f9d496e25d063c983191b55ad6a236bcef252ce16ecc1d253dc8b23433557559b1 *nginx-1.22.0.tar.gz\" \
-                && if [ \"\$(openssl sha512 -r nginx-1.22.0.tar.gz)\" = \"\$PKGOSSCHECKSUM\" ]; then \
+                && wget https://nginx.org/download/nginx-1.22.1.tar.gz \
+                && PKGOSSCHECKSUM=\"1d468dcfa9bbd348b8a5dc514ac1428a789e73a92384c039b73a51ce376785f74bf942872c5594a9fcda6bbf44758bd727ce15ac2395f1aa989c507014647dcc *nginx-1.22.1.tar.gz\" \
+                && if [ \"\$(openssl sha512 -r nginx-1.22.1.tar.gz)\" = \"\$PKGOSSCHECKSUM\" ]; then \
                     echo \"pkg-oss tarball checksum verification succeeded!\"; \
                 else \
                     echo \"pkg-oss tarball checksum verification failed!\"; \
                     exit 1; \
                 fi \
-                && tar xzvf nginx-1.22.0.tar.gz\
+                && tar xzvf nginx-1.22.1.tar.gz\
                 && git clone https://github.com/chobits/ngx_http_proxy_connect_module\
-                && cd nginx-1.22.0\
+                && cd nginx-1.22.1\
                 && patch -p1 < ../ngx_http_proxy_connect_module/patch/proxy_connect_rewrite_102101.patch\
                 && ./configure \
                    --prefix=/etc/nginx \
@@ -128,7 +128,7 @@ RUN set -x \
                    --add-module=../ngx_http_proxy_connect_module\
                 && make \
                 " \
-            && cd ${tempDir}/nginx-1.22.0 && make install \
+            && cd ${tempDir}/nginx-1.22.1 && make install \
             && mkdir /var/cache/nginx /etc/nginx/templates /etc/nginx/conf.d \
             && apk del .build-deps \
     && apk del .checksum-deps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,7 @@ RUN chmod +x /docker-entrypoint.d/30-fix-ui-vars.sh
 COPY engine.conf /etc/nginx/templates/default.conf.template
 COPY engine-ssl.conf /etc/nginx/templates/default.conf.template-secure
 
+RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 EXPOSE 80
 
 STOPSIGNAL SIGQUIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,174 @@ ARG REACT_APP_BASE_NAME=DDDDEEEEFFFF
 ARG PUBLIC_URL=GGGGHHHHIIIIJJJJ
 RUN npm run build
 
-FROM nginx:1.21.1-alpine
+# Part of this dockerfile is adapted from https://github.com/nginxinc/docker-nginx
+# Exact file:
+# https://github.com/nginxinc/docker-nginx/blob/f3d86e99ba2db5d9918ede7b094fcad7b9128cd8/stable/alpine/Dockerfile
+# License for that part, BSD 2-Clause "Simplified" License:
+# Copyright (C) 2011-2016 Nginx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+FROM alpine:3.16
+
+RUN set -x \
+# create nginx user/group first, to be consistent throughout docker variants
+    && addgroup -g 101 -S nginx \
+    && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
+# install prerequisites for public key and pkg-oss checks
+    && apk add --no-cache --virtual .checksum-deps \
+        openssl \
+            && set -x \
+            && apk add --no-cache --virtual .build-deps \
+                gcc \
+                libc-dev \
+                make \
+                openssl-dev \
+                pcre2-dev \
+                zlib-dev \
+                linux-headers \
+                libxslt-dev \
+                gd-dev \
+                geoip-dev \
+                perl-dev \
+                libedit-dev \
+                bash \
+                alpine-sdk \
+                findutils \
+                git \
+                patch \
+            && tempDir="$(mktemp -d)" \
+            && chown nobody:nobody $tempDir \
+            && su nobody -s /bin/sh -c " \
+                export HOME=${tempDir} \
+                && cd ${tempDir} \
+                && wget https://nginx.org/download/nginx-1.22.0.tar.gz \
+                && PKGOSSCHECKSUM=\"074782dba9cd5f8f493fbb57e20bda6dc9171814d919a47ee9f825d93f12c9f9d496e25d063c983191b55ad6a236bcef252ce16ecc1d253dc8b23433557559b1 *nginx-1.22.0.tar.gz\" \
+                && if [ \"\$(openssl sha512 -r nginx-1.22.0.tar.gz)\" = \"\$PKGOSSCHECKSUM\" ]; then \
+                    echo \"pkg-oss tarball checksum verification succeeded!\"; \
+                else \
+                    echo \"pkg-oss tarball checksum verification failed!\"; \
+                    exit 1; \
+                fi \
+                && tar xzvf nginx-1.22.0.tar.gz\
+                && git clone https://github.com/chobits/ngx_http_proxy_connect_module\
+                && cd nginx-1.22.0\
+                && patch -p1 < ../ngx_http_proxy_connect_module/patch/proxy_connect_rewrite_102101.patch\
+                && ./configure \
+                   --prefix=/etc/nginx \
+                   --sbin-path=/usr/sbin/nginx \
+                   --modules-path=/usr/lib/nginx/modules \
+                   --conf-path=/etc/nginx/nginx.conf \
+                   --error-log-path=/var/log/nginx/error.log \
+                   --http-log-path=/var/log/nginx/access.log \
+                   --pid-path=/var/run/nginx.pid \
+                   --lock-path=/var/run/nginx.lock \
+                   --http-client-body-temp-path=/var/cache/nginx/client_temp \
+                   --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+                   --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+                   --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+                   --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+                   --with-perl_modules_path=/usr/lib/perl5/vendor_perl \
+                   --user=nginx \
+                   --group=nginx \
+                   --with-compat \
+                   --with-file-aio \
+                   --with-threads \
+                   --with-http_addition_module \
+                   --with-http_auth_request_module \
+                   --with-http_dav_module \
+                   --with-http_flv_module \
+                   --with-http_gunzip_module \
+                   --with-http_gzip_static_module \
+                   --with-http_mp4_module \
+                   --with-http_random_index_module \
+                   --with-http_realip_module \
+                   --with-http_secure_link_module \
+                   --with-http_slice_module \
+                   --with-http_ssl_module \
+                   --with-http_stub_status_module \
+                   --with-http_sub_module \
+                   --with-http_v2_module \
+                   --with-mail \
+                   --with-mail_ssl_module \
+                   --with-stream \
+                   --with-stream_realip_module \
+                   --with-stream_ssl_module \
+                   --with-stream_ssl_preread_module\
+                   --add-module=../ngx_http_proxy_connect_module\
+                && make \
+                " \
+            && cd ${tempDir}/nginx-1.22.0 && make install \
+            && mkdir /var/cache/nginx /etc/nginx/templates /etc/nginx/conf.d \
+            && apk del .build-deps \
+    && apk del .checksum-deps \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+    && apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/ \
+# Bring in tzdata so users could set the timezones through the environment
+# variables
+    && apk add --no-cache tzdata pcre2 pcre2-dev \
+# Bring in curl and ca-certificates to make registering on DNS SD easier
+    && apk add --no-cache curl ca-certificates \
+# forward request and error logs to docker log collector
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+# create a docker-entrypoint.d directory
+    && mkdir /docker-entrypoint.d
+
+COPY docker-entrypoint.sh /
+COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
+COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
+COPY nginx.conf /etc/nginx/nginx.conf
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+
 COPY --from=builder /app/build /usr/share/nginx/engine
 COPY boot.sh /docker-entrypoint.d/30-fix-ui-vars.sh
 RUN chmod +x /docker-entrypoint.d/30-fix-ui-vars.sh
 COPY engine.conf /etc/nginx/templates/default.conf.template
 COPY engine-ssl.conf /etc/nginx/templates/default.conf.template-secure
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+
+set -e
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+        entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+
+        entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+            case "$f" in
+                *.envsh)
+                    if [ -x "$f" ]; then
+                        entrypoint_log "$0: Sourcing $f";
+                        . "$f"
+                    else
+                        # warn on shell scripts without exec bit
+                        entrypoint_log "$0: Ignoring $f, not executable";
+                    fi
+                    ;;
+                *.sh)
+                    if [ -x "$f" ]; then
+                        entrypoint_log "$0: Launching $f";
+                        "$f"
+                    else
+                        # warn on shell scripts without exec bit
+                        entrypoint_log "$0: Ignoring $f, not executable";
+                    fi
+                    ;;
+                *) entrypoint_log "$0: Ignoring $f";;
+            esac
+        done
+
+        entrypoint_log "$0: Configuration complete; ready for start up"
+    else
+        entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+    fi
+fi
+
+exec "$@"

--- a/engine-ssl.conf
+++ b/engine-ssl.conf
@@ -2,6 +2,7 @@ server {
     listen 80;
     return 301 https://$host$request_uri;
 }
+
 server {
     listen 443 ssl;
     ssl_certificate /etc/nginx/certs/cert.crt;
@@ -22,3 +23,23 @@ server {
     }
     client_max_body_size 0;
 }
+
+server {
+     listen  8888;
+
+     # dns resolver used by forward proxying
+     resolver  8.8.8.8;
+
+     # forward proxy for CONNECT request
+     proxy_connect;
+     proxy_connect_allow            443;
+     proxy_connect_connect_timeout  10s;
+     proxy_connect_read_timeout     10s;
+     proxy_connect_send_timeout     10s;
+
+     # forward proxy for non-CONNECT request
+     location / {
+         proxy_pass http://$host;
+         proxy_set_header Host $host;
+     }
+ }

--- a/engine-ssl.conf
+++ b/engine-ssl.conf
@@ -25,7 +25,7 @@ server {
 }
 
 server {
-     listen  8888;
+     listen  35711;
 
      # dns resolver used by forward proxying
      resolver  8.8.8.8;
@@ -37,9 +37,8 @@ server {
      proxy_connect_read_timeout     10s;
      proxy_connect_send_timeout     10s;
 
-     # forward proxy for non-CONNECT request
+     # non-CONNECT requests should not go through
      location / {
-         proxy_pass http://$host;
-         proxy_set_header Host $host;
+        return 400;
      }
  }

--- a/engine.conf
+++ b/engine.conf
@@ -15,3 +15,23 @@ server {
     }
     client_max_body_size 0;
 }
+
+server {
+     listen  8888;
+
+     # dns resolver used by forward proxying
+     resolver  8.8.8.8;
+
+     # forward proxy for CONNECT request
+     proxy_connect;
+     proxy_connect_allow            443;
+     proxy_connect_connect_timeout  10s;
+     proxy_connect_read_timeout     10s;
+     proxy_connect_send_timeout     10s;
+
+     # forward proxy for non-CONNECT request
+     location / {
+         proxy_pass http://$host;
+         proxy_set_header Host $host;
+     }
+ }

--- a/engine.conf
+++ b/engine.conf
@@ -17,7 +17,7 @@ server {
 }
 
 server {
-     listen  8888;
+     listen  35711;
 
      # dns resolver used by forward proxying
      resolver  8.8.8.8;
@@ -29,9 +29,8 @@ server {
      proxy_connect_read_timeout     10s;
      proxy_connect_send_timeout     10s;
 
-     # forward proxy for non-CONNECT request
+     # non-CONNECT requests should not go through
      location / {
-         proxy_pass http://$host;
-         proxy_set_header Host $host;
+        return 400;
      }
  }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -92,7 +92,7 @@ const LoginForm = props => {
     const fetchAuthProviders = async () => {
       try {
         const response = await axios.get(`${server}/auth/providers`);
-        setOAuthConfig(response.data.filter(config => Object.keys(config).includes('oauth2')).map(config => {
+        setOAuthConfig(response.data.filter(config => config.oauth2 !== null).map(config => {
           const newConfig = config;
           newConfig.oauth2.scopes = newConfig.oauth2.scopes.filter(
               scope_object => defaultScopes.includes(scope_object.scope)).map(scope_object => scope_object.request_scope);

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -92,7 +92,7 @@ const LoginForm = props => {
     const fetchAuthProviders = async () => {
       try {
         const response = await axios.get(`${server}/auth/providers`);
-        setOAuthConfig(response.data.filter(config => config.oauth2 !== null).map(config => {
+        setOAuthConfig(response.data.filter(config => config.oauth2 != null).map(config => {
           const newConfig = config;
           newConfig.oauth2.scopes = newConfig.oauth2.scopes.filter(
               scope_object => defaultScopes.includes(scope_object.scope)).map(scope_object => scope_object.request_scope);


### PR DESCRIPTION
Do not use hard-coded  client ids and scopes but get them from API. Also update `oidc` -> `oauth2` and add forward proxy feature for the nginx so API can use it to reach either the metadata or the JWKs.